### PR TITLE
Allow debugger to load code you're tdding

### DIFF
--- a/src/tddreloader.erl
+++ b/src/tddreloader.erl
@@ -114,7 +114,7 @@ doit(From, To) ->
 
 compile(Filename) ->
   io:format("~nCompiling ~p ... ", [Filename]),
-  case compile:file(Filename, {outdir, "ebin"}) of
+  case compile:file(Filename, [{outdir, "ebin"},debug_info]) of
     {ok, Module} ->
       io:format("succeeded (~p)~n", [Module]),
       reload(Module);


### PR DESCRIPTION
I'd like to be able to use debugger:start() while using tddreloader. The debugger requires that files loaded be compiled with debug_info. This compiles those files with debug_info.
