### PR TITLE
Loads include directory when compiling/testing.

### DIFF
--- a/src/tddreloader.erl
+++ b/src/tddreloader.erl
@@ -114,7 +114,7 @@ doit(From, To) ->
 
 compile(Filename) ->
   io:format("~nCompiling ~p ...~n", [Filename]),
-  case compile:file(Filename, [{outdir, "ebin"}, debug_info, report]) of
+  case compile:file(Filename, [{outdir, "ebin"}, {i, "include"}, debug_info, report]) of
     {ok, Module} ->
       io:format("succeeded (~p)~n", [Module]),
       reload(Module);


### PR DESCRIPTION
I would like to be able to load **include** files when compiling/testing with cowboy application (on **'make shell'**), but couldn't load **include** files after saving source file which has a **"-include"** line.
So, I added options to **compile:file: {i, "include"}.**

Please check the direction of my improvement.
